### PR TITLE
Fix failing benchmark

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,4 +66,4 @@ jobs:
 
       - name: "Benchmark"
         run: |
-          cargo bench
+          cargo bench --features bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "num",
  "quickcheck",
  "siphasher",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -621,6 +622,30 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ harness = false
 [[bench]]
 name = "siphash"
 harness = false
+
+# We use this feature for producing a benchmark build that exposes some
+# internal functions - otherwise we cannot compile the benchmark due to the
+# internal functions not being exported.
+[features]
+bench = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,14 @@
 //! ```
 
 mod encode;
-mod siphash;
 mod ranges;
+mod siphash;
 
 pub use encode::*;
 pub use ranges::*;
+
+#[cfg(feature = "bench")]
+pub use siphash::*;
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
The siphash module was no longer publically exported. And it shouldn't
be, but it caused a benchmark to fail to compile.

So we define "bench" feature that when enabled will publicly export
the siphash code so that it can be benchmarked.